### PR TITLE
 fix the root_path

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,6 @@
 Factotum::Application.routes.draw do
 
-  if Rails.env.development? && false
+  if Rails.env.development?
     root to: 'development#index'
   else
     root to: "refworks_password_resets#new"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,9 @@
 Factotum::Application.routes.draw do
 
-  if Rails.env.development?
+  if Rails.env.development? && false
     root to: 'development#index'
+  else
+    root to: "refworks_password_resets#new"
   end
 
   get 'pages/ping' => 'high_voltage/pages#show', id: 'ping'


### PR DESCRIPTION
I think that the problem on prod is root is no longer defined.  There are a couple redirects to the root path this should state that they go to the page you see when you land on /utilities

