### PR TITLE
INC0096834

### DIFF
--- a/app/models/search/primo_deep_link_redirect.rb
+++ b/app/models/search/primo_deep_link_redirect.rb
@@ -67,15 +67,18 @@ class Search::PrimoDeepLinkRedirect < Search::Redirect
   def query_params
     # If there's no query term we only need a very basic set of parameters
     params_hash = {
-      fn: 'search',
-      ct: 'search',
-      initialSearch: true,
-      mode: mode,
+      institution: institution,
+      vid: vid,
       tab: tab,
+      mode: mode,
+      query: query_param,
+      search_scope: search_scope,
       indx: 1,
-      dum: true,
-      srt: 'rank',
-      vid: vid
+      bulkSize: 10,
+      highlight: 'true',
+      dym: 'true',
+      onCampus: 'false',
+      pcAvailabiltyMode: pc_availabilty_mode,
     }
     if mode == 'Advanced'
       # For some reason the advanced search will not prefill the query in the search box unless the "vl(freeText0)" GET parameter is specified

--- a/app/models/search/primo_deep_link_redirect.rb
+++ b/app/models/search/primo_deep_link_redirect.rb
@@ -67,18 +67,16 @@ class Search::PrimoDeepLinkRedirect < Search::Redirect
   def query_params
     # If there's no query term we only need a very basic set of parameters
     params_hash = {
-      institution: institution,
-      vid: vid,
-      tab: tab,
+      fn: 'search',
+      ct: 'search',
+      initialSearch: true,
       mode: mode,
-      query: query_param,
-      search_scope: search_scope,
+      tab: tab,
       indx: 1,
-      bulkSize: 10,
-      highlight: 'true',
-      dym: 'true',
-      onCampus: 'false',
-      pcAvailabiltyMode: pc_availabilty_mode,
+      dum: true,
+      srt: 'rank',
+      vid: vid,
+      'vl(freeText0)': query_param
     }
     if mode == 'Advanced'
       # For some reason the advanced search will not prefill the query in the search box unless the "vl(freeText0)" GET parameter is specified

--- a/app/models/search/primo_deep_link_redirect.rb
+++ b/app/models/search/primo_deep_link_redirect.rb
@@ -75,9 +75,15 @@ class Search::PrimoDeepLinkRedirect < Search::Redirect
       indx: 1,
       dum: true,
       srt: 'rank',
-      vid: vid
+      vid: vid,
+      'vl(freeText0)': query_param
     }
-    params_hash['vl(freeText0)'] = query_param
+    if mode == 'Advanced'
+      # For some reason the advanced search will not prefill the query in the search box unless the "vl(freeText0)" GET parameter is specified
+      params_hash['vl(freeText0)'] = params[:q]
+    else
+      params_hash['vl(freeText0)'] = query_param
+    end
     params_hash
   end
 

--- a/app/models/search/primo_deep_link_redirect.rb
+++ b/app/models/search/primo_deep_link_redirect.rb
@@ -70,6 +70,9 @@ class Search::PrimoDeepLinkRedirect < Search::Redirect
       institution: institution,
       vid: vid,
       tab: tab,
+      fn: 'search',
+      ct: 'search',
+      initialSearch: true,
       mode: mode,
       query: query_param,
       search_scope: search_scope,
@@ -79,6 +82,9 @@ class Search::PrimoDeepLinkRedirect < Search::Redirect
       dym: 'true',
       onCampus: 'false',
       pcAvailabiltyMode: pc_availabilty_mode,
+      dum: true,
+      srt: 'rank',
+      vid: vid,
     }
     if mode == 'Advanced'
       # For some reason the advanced search will not prefill the query in the search box unless the "vl(freeText0)" GET parameter is specified

--- a/app/models/search/primo_deep_link_redirect.rb
+++ b/app/models/search/primo_deep_link_redirect.rb
@@ -77,7 +77,7 @@ class Search::PrimoDeepLinkRedirect < Search::Redirect
       srt: 'rank',
       vid: vid
     }
-    params_hash['vl(freeText0)'] = params[:q]
+    params_hash['vl(freeText0)'] = query_param
     params_hash
   end
 

--- a/app/models/search/primo_deep_link_redirect.rb
+++ b/app/models/search/primo_deep_link_redirect.rb
@@ -67,20 +67,22 @@ class Search::PrimoDeepLinkRedirect < Search::Redirect
   def query_params
     # If there's no query term we only need a very basic set of parameters
     params_hash = {
-      institution: institution,
-      vid: vid,
-      tab: tab,
+      fn: 'search',
+      ct: 'search',
+      initialSearch: true,
       mode: mode,
-      query: query_param,
-      search_scope: search_scope,
+      tab: tab,
       indx: 1,
-      bulkSize: 10,
-      highlight: 'true',
-      dym: 'true',
-      onCampus: 'false',
-      pcAvailabiltyMode: pc_availabilty_mode,
+      dum: true,
+      srt: 'rank',
+      vid: vid
     }
-    params_hash['vl(freeText0)'] = query_param
+    if mode == 'Advanced'
+      # For some reason the advanced search will not prefill the query in the search box unless the "vl(freeText0)" GET parameter is specified
+      params_hash['vl(freeText0)'] = params[:q]
+    else
+      params_hash['vl(freeText0)'] = query_param
+    end
     params_hash
   end
 
@@ -103,7 +105,7 @@ class Search::PrimoDeepLinkRedirect < Search::Redirect
   end
 
   def path
-    '/primo_library/libweb/action/dlSearch.do'
+    '/primo_library/libweb/action/Search.do'
   end
 
   def redirect_name

--- a/app/models/search/primo_deep_link_redirect.rb
+++ b/app/models/search/primo_deep_link_redirect.rb
@@ -70,9 +70,6 @@ class Search::PrimoDeepLinkRedirect < Search::Redirect
       institution: institution,
       vid: vid,
       tab: tab,
-      fn: 'search',
-      ct: 'search',
-      initialSearch: true,
       mode: mode,
       query: query_param,
       search_scope: search_scope,
@@ -82,16 +79,8 @@ class Search::PrimoDeepLinkRedirect < Search::Redirect
       dym: 'true',
       onCampus: 'false',
       pcAvailabiltyMode: pc_availabilty_mode,
-      dum: true,
-      srt: 'rank',
-      vid: vid,
     }
-    if mode == 'Advanced'
-      # For some reason the advanced search will not prefill the query in the search box unless the "vl(freeText0)" GET parameter is specified
-      params_hash['vl(freeText0)'] = params[:q]
-    else
-      params_hash['vl(freeText0)'] = query_param
-    end
+    params_hash['vl(freeText0)'] = query_param
     params_hash
   end
 

--- a/app/models/search/primo_deep_link_redirect.rb
+++ b/app/models/search/primo_deep_link_redirect.rb
@@ -75,8 +75,7 @@ class Search::PrimoDeepLinkRedirect < Search::Redirect
       indx: 1,
       dum: true,
       srt: 'rank',
-      vid: vid,
-      'vl(freeText0)': query_param
+      vid: vid
     }
     if mode == 'Advanced'
       # For some reason the advanced search will not prefill the query in the search box unless the "vl(freeText0)" GET parameter is specified

--- a/app/models/search/primo_deep_link_redirect.rb
+++ b/app/models/search/primo_deep_link_redirect.rb
@@ -75,13 +75,9 @@ class Search::PrimoDeepLinkRedirect < Search::Redirect
       indx: 1,
       dum: true,
       srt: 'rank',
-      vid: vid,
-      'vl(freeText0)': query_param
+      vid: vid
     }
-    if mode == 'Advanced'
-      # For some reason the advanced search will not prefill the query in the search box unless the "vl(freeText0)" GET parameter is specified
-      params_hash['vl(freeText0)'] = params[:q]
-    end
+    params_hash['vl(freeText0)'] = params[:q]
     params_hash
   end
 

--- a/config/search.yml
+++ b/config/search.yml
@@ -1,7 +1,7 @@
 default:
   library: 'http://librarypprd.library.nd.edu'
   ejournals: 'http://ejlpprd.library.nd.edu'
-  primo: 'http://onesearchpprd.library.nd.edu'
+  primo: 'http://onesearch.library.nd.edu'
   xerxes: 'http://xerxespprd.library.nd.edu'
 production:
   library: 'http://library.nd.edu'

--- a/spec/models/search/primo_deep_link_redirect_spec.rb
+++ b/spec/models/search/primo_deep_link_redirect_spec.rb
@@ -31,11 +31,6 @@ describe Search::PrimoDeepLinkRedirect do
       expect(subject.query_params[:mode]).to be == 'Advanced'
       expect(subject.query_params['vl(freeText0)']).to be == new_params[:q]
     end
-
-    # it "uses #pc_availabilty_mode to determine the pcAvailabiltyMode " do
-    #   expect(subject).to receive(:pc_availabilty_mode).and_return("PCMODE")
-    #   expect(subject.query_params.fetch(:pcAvailabiltyMode)).to eq("PCMODE")
-    # end
   end
 
   describe '#mode' do
@@ -115,12 +110,6 @@ describe Search::PrimoDeepLinkRedirect do
       expect(subject.base_url).to be == "http://onesearchpprd.library.nd.edu"
     end
   end
-
-  # describe '#query_string' do
-  #   it "adds the displayField parameters for highlighting" do
-  #     expect(subject.query_string).to match(/&displayField=title&displayField=creator/)
-  #   end
-  # end
 
   describe '#url' do
     it "includes the base_url, path, and query_string" do

--- a/spec/models/search/primo_deep_link_redirect_spec.rb
+++ b/spec/models/search/primo_deep_link_redirect_spec.rb
@@ -12,18 +12,16 @@ describe Search::PrimoDeepLinkRedirect do
   describe '#query_params' do
     it "changes q to query and adds stats_search_type" do
       expect(subject.query_params).to be == {
-        query: 'any,contains,example',
-        institution: 'NDU',
-        vid: 'NDU',
-        tab: 'onesearch',
-        search_scope: 'malc_blended',
-        indx: 1,
-        bulkSize: 10,
-        highlight: 'true',
-        dym: 'true',
-        onCampus: 'false',
+        fn: 'search',
+        ct: 'search',
+        initialSearch: true,
         mode: 'Basic',
-        pcAvailabiltyMode: 'true',
+        tab: 'onesearch',
+        indx: 1,
+        dum: true,
+        srt: 'rank',
+        vid: 'NDU',
+        'vl(freeText0)': 'any,contains,example'
       }
     end
 
@@ -34,10 +32,10 @@ describe Search::PrimoDeepLinkRedirect do
       expect(subject.query_params['vl(freeText0)']).to be == new_params[:q]
     end
 
-    it "uses #pc_availabilty_mode to determine the pcAvailabiltyMode " do
-      expect(subject).to receive(:pc_availabilty_mode).and_return("PCMODE")
-      expect(subject.query_params.fetch(:pcAvailabiltyMode)).to eq("PCMODE")
-    end
+    # it "uses #pc_availabilty_mode to determine the pcAvailabiltyMode " do
+    #   expect(subject).to receive(:pc_availabilty_mode).and_return("PCMODE")
+    #   expect(subject.query_params.fetch(:pcAvailabiltyMode)).to eq("PCMODE")
+    # end
   end
 
   describe '#mode' do
@@ -118,11 +116,11 @@ describe Search::PrimoDeepLinkRedirect do
     end
   end
 
-  describe '#query_string' do
-    it "adds the displayField parameters for highlighting" do
-      expect(subject.query_string).to match(/&displayField=title&displayField=creator/)
-    end
-  end
+  # describe '#query_string' do
+  #   it "adds the displayField parameters for highlighting" do
+  #     expect(subject.query_string).to match(/&displayField=title&displayField=creator/)
+  #   end
+  # end
 
   describe '#url' do
     it "includes the base_url, path, and query_string" do


### PR DESCRIPTION
**Service now description:**

When sending a search from the search box to the NDCatalog, then
clicking Advanced Search, the context switches to OneSearch Advanced
Search and the search query is not carried.

**Notes:**

It appears that the format that onesearch expects has changed.

This url generated by factotum did not work:

`http://onesearch.library.nd.edu/primo_library/libweb/action/dlSearch.do
?bulkSize=10&dym=true&highlight=true&indx=1&institution=NDU&mode=Basic&o
nCampus=false&pcAvailabiltyMode=true&query=any%2Ccontains%2Cglobal+warmi
ng&search_scope=nd_campus&tab=nd_campus&vid=NDU&displayField=title&displ
ayField=creator`

And the url generated by a page on onesearch did work:

`http://onesearch.library.nd.edu/primo_library/libweb/action/search.do?f
n=search&ct=search&initialSearch=true&mode=Basic&tab=nd_campus&indx=1&du
m=true&srt=rank&vid=NDU&frbg=&tb=t&vl%28freeText0%29=global+warming&scp.
scps=scope%3A%28hathi_pub%29%2Cscope%3A%28ndulawrestricted%29%2Cscope%3A
%28dtlrestricted%29%2Cscope%3A%28NDU%29%2Cscope%3A%28NDLAW%29%2Cscope%3A
%28ndu_digitool%29`

**Solution:**

I modified the url generated by factotum to more closely match what
was going on on onesearch.

I tested a search at the test url:
`http://localhost:3003/utilities/find/demo.html#tab_cat` and it behaved
as expected and after modifying the spec to pass the parameters most of
the tests passed without issue. I removed two that were causing errors
and did not appear to apply any more.