### PR TITLE
Add new method for requiring authentication in certain controllers

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -7,14 +7,9 @@ class ApplicationController < ActionController::Base
 
   # Okta
   # This method can be used for testing but is not currently used by the application
-  def user_is_logged_in?
+  def login_user!
     if !session[:netid]
-      print("this user is not logged in\n")
-      print("SESSION: " + session.keys.to_s + "\n")
       redirect_to user_oktaoauth_omniauth_authorize_path
-    else
-      print "USER IS LOGGED IN: " + session[:netid] + "\n\n"
-      print("OKTA AUTH INFO: " + session[:oktastate].to_s + "\n\n")
     end
   end
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -6,7 +6,6 @@ class ApplicationController < ActionController::Base
   layout :determine_layout
 
   # Okta
-  # This method can be used for testing but is not currently used by the application
   def login_user!
     if !session[:netid]
       redirect_to user_oktaoauth_omniauth_authorize_path

--- a/app/controllers/cataloging/admin/formats_controller.rb
+++ b/app/controllers/cataloging/admin/formats_controller.rb
@@ -1,5 +1,5 @@
 class Cataloging::Admin::FormatsController < Cataloging::AdminController
-  before_filter :authenticate_user!
+  before_filter ::login_user!
 
   layout "generic_modal"
 

--- a/app/controllers/cataloging/admin/formats_controller.rb
+++ b/app/controllers/cataloging/admin/formats_controller.rb
@@ -1,5 +1,5 @@
 class Cataloging::Admin::FormatsController < Cataloging::AdminController
-  before_filter ::login_user!
+  before_filter :login_user!
 
   layout "generic_modal"
 

--- a/app/controllers/cataloging/admin/locations_controller.rb
+++ b/app/controllers/cataloging/admin/locations_controller.rb
@@ -1,5 +1,5 @@
 class Cataloging::Admin::LocationsController < Cataloging::AdminController
-  before_filter ::login_user!
+  before_filter :login_user!
 
   layout "generic_modal"
 

--- a/app/controllers/cataloging/admin/locations_controller.rb
+++ b/app/controllers/cataloging/admin/locations_controller.rb
@@ -1,5 +1,5 @@
 class Cataloging::Admin::LocationsController < Cataloging::AdminController
-  before_filter :authenticate_user!
+  before_filter ::login_user!
 
   layout "generic_modal"
 

--- a/app/controllers/cataloging/admin/locations_formats_controller.rb
+++ b/app/controllers/cataloging/admin/locations_formats_controller.rb
@@ -1,5 +1,5 @@
 class Cataloging::Admin::LocationsFormatsController < Cataloging::AdminController
-  before_filter :authenticate_user!
+  before_filter ::login_user!
 
   layout "generic_modal"
 

--- a/app/controllers/cataloging/admin/locations_formats_controller.rb
+++ b/app/controllers/cataloging/admin/locations_formats_controller.rb
@@ -1,5 +1,5 @@
 class Cataloging::Admin::LocationsFormatsController < Cataloging::AdminController
-  before_filter ::login_user!
+  before_filter :login_user!
 
   layout "generic_modal"
 

--- a/app/controllers/cataloging/admin/special_procedure_types_controller.rb
+++ b/app/controllers/cataloging/admin/special_procedure_types_controller.rb
@@ -1,5 +1,5 @@
 class Cataloging::Admin::SpecialProcedureTypesController < Cataloging::AdminController
-  before_filter :authenticate_user!
+  before_filter ::login_user!
 
   layout "generic_modal"
 

--- a/app/controllers/cataloging/admin/special_procedure_types_controller.rb
+++ b/app/controllers/cataloging/admin/special_procedure_types_controller.rb
@@ -1,5 +1,5 @@
 class Cataloging::Admin::SpecialProcedureTypesController < Cataloging::AdminController
-  before_filter ::login_user!
+  before_filter :login_user!
 
   layout "generic_modal"
 

--- a/app/controllers/cataloging/admin/transfer_types_controller.rb
+++ b/app/controllers/cataloging/admin/transfer_types_controller.rb
@@ -1,5 +1,5 @@
 class Cataloging::Admin::TransferTypesController < Cataloging::AdminController
-  before_filter :authenticate_user!
+  before_filter ::login_user!
 
   layout "generic_modal"
 

--- a/app/controllers/cataloging/admin/transfer_types_controller.rb
+++ b/app/controllers/cataloging/admin/transfer_types_controller.rb
@@ -1,5 +1,5 @@
 class Cataloging::Admin::TransferTypesController < Cataloging::AdminController
-  before_filter ::login_user!
+  before_filter :login_user!
 
   layout "generic_modal"
 

--- a/app/controllers/cataloging/admin_controller.rb
+++ b/app/controllers/cataloging/admin_controller.rb
@@ -1,5 +1,5 @@
 class Cataloging::AdminController < ApplicationController
-  before_filter :authenticate_user!
+  before_filter ::login_user!
   before_filter :authorized?
 
 

--- a/app/controllers/cataloging/admin_controller.rb
+++ b/app/controllers/cataloging/admin_controller.rb
@@ -1,5 +1,5 @@
 class Cataloging::AdminController < ApplicationController
-  before_filter ::login_user!
+  before_filter :login_user!
   before_filter :authorized?
 
 

--- a/app/controllers/cataloging/entries_controller.rb
+++ b/app/controllers/cataloging/entries_controller.rb
@@ -1,5 +1,5 @@
 class Cataloging::EntriesController < ApplicationController
-  before_filter ::login_user!
+  before_filter :login_user!
   before_filter :cataloging_user?
 
   layout Proc.new { |controller| controller.request.xhr? ? false : "application" }

--- a/app/controllers/cataloging/entries_controller.rb
+++ b/app/controllers/cataloging/entries_controller.rb
@@ -1,5 +1,5 @@
 class Cataloging::EntriesController < ApplicationController
-  before_filter :authenticate_user!
+  before_filter ::login_user!
   before_filter :cataloging_user?
 
   layout Proc.new { |controller| controller.request.xhr? ? false : "application" }

--- a/app/controllers/cataloging/reports_controller.rb
+++ b/app/controllers/cataloging/reports_controller.rb
@@ -1,5 +1,5 @@
 class Cataloging::ReportsController < ApplicationController
-  before_filter :authenticate_user!
+  before_filter ::login_user!
   before_filter :cataloging_user?
 
   layout Proc.new { |controller| controller.request.params[:print] ? "print" : "application" }

--- a/app/controllers/cataloging/reports_controller.rb
+++ b/app/controllers/cataloging/reports_controller.rb
@@ -1,5 +1,5 @@
 class Cataloging::ReportsController < ApplicationController
-  before_filter ::login_user!
+  before_filter :login_user!
   before_filter :cataloging_user?
 
   layout Proc.new { |controller| controller.request.params[:print] ? "print" : "application" }

--- a/app/controllers/cataloging/users_controller.rb
+++ b/app/controllers/cataloging/users_controller.rb
@@ -1,5 +1,5 @@
 class Cataloging::UsersController < ApplicationController
-  before_filter :authenticate_user!
+  before_filter :login_user!
   before_filter :cataloging_user?
 
   def index

--- a/app/controllers/directory/admin_controller.rb
+++ b/app/controllers/directory/admin_controller.rb
@@ -1,5 +1,5 @@
 class Directory::AdminController < Directory::ApplicationController
-  before_filter :authenticate_user!
+  before_filter ::login_user!
 
 
   def check_admin_permission!

--- a/app/controllers/directory/admin_controller.rb
+++ b/app/controllers/directory/admin_controller.rb
@@ -1,5 +1,5 @@
 class Directory::AdminController < Directory::ApplicationController
-  before_filter ::login_user!
+  before_filter :login_user!
 
 
   def check_admin_permission!

--- a/app/controllers/just_say_yes_orders_controller.rb
+++ b/app/controllers/just_say_yes_orders_controller.rb
@@ -1,5 +1,5 @@
 class JustSayYesOrdersController < ApplicationController
-  before_filter :authenticate_user!
+  before_filter ::login_user!
 
   def index
     new

--- a/app/controllers/just_say_yes_orders_controller.rb
+++ b/app/controllers/just_say_yes_orders_controller.rb
@@ -1,5 +1,5 @@
 class JustSayYesOrdersController < ApplicationController
-  before_filter ::login_user!
+  before_filter :login_user!
 
   def index
     new

--- a/app/controllers/monographic_orders_controller.rb
+++ b/app/controllers/monographic_orders_controller.rb
@@ -1,6 +1,6 @@
 class MonographicOrdersController < ApplicationController
   before_filter :store_location
-  before_filter :authenticate_user!
+  before_filter ::login_user!
 
   def index
     @search = AcquisitionOrderSearch.new(params[:search])

--- a/app/controllers/monographic_orders_controller.rb
+++ b/app/controllers/monographic_orders_controller.rb
@@ -1,6 +1,6 @@
 class MonographicOrdersController < ApplicationController
   before_filter :store_location
-  before_filter ::login_user!
+  before_filter :login_user!
 
   def index
     @search = AcquisitionOrderSearch.new(params[:search])

--- a/app/controllers/print_controller.rb
+++ b/app/controllers/print_controller.rb
@@ -1,5 +1,5 @@
 class PrintController < ApplicationController
-  before_filter :authenticate_user!, :except => :show
+  before_filter ::login_user!, :except => :show
   before_filter :test_environment!, :only => :print
 
   protected

--- a/app/controllers/print_controller.rb
+++ b/app/controllers/print_controller.rb
@@ -1,5 +1,5 @@
 class PrintController < ApplicationController
-  before_filter ::login_user!, :except => :show
+  before_filter :login_user!, :except => :show
   before_filter :test_environment!, :only => :print
 
   protected

--- a/app/controllers/purchase_requests_controller.rb
+++ b/app/controllers/purchase_requests_controller.rb
@@ -1,5 +1,5 @@
 class PurchaseRequestsController < ApplicationController
-  before_filter :authenticate_user!, except: [:show]
+  before_filter ::login_user!, except: [:show]
 
   def new
     @purchase_request = PurchaseRequest.new

--- a/app/controllers/purchase_requests_controller.rb
+++ b/app/controllers/purchase_requests_controller.rb
@@ -1,5 +1,5 @@
 class PurchaseRequestsController < ApplicationController
-  before_filter ::login_user!, except: [:show]
+  before_filter :login_user!, except: [:show]
 
   def new
     @purchase_request = PurchaseRequest.new

--- a/app/controllers/selectors_controller.rb
+++ b/app/controllers/selectors_controller.rb
@@ -1,5 +1,5 @@
 class SelectorsController < ApplicationController
-  before_filter ::login_user!, :except => [:funds]
+  before_filter :login_user!, :except => [:funds]
   before_filter :check_admin!, :except => [:funds]
 
   def index

--- a/app/controllers/selectors_controller.rb
+++ b/app/controllers/selectors_controller.rb
@@ -1,5 +1,5 @@
 class SelectorsController < ApplicationController
-  before_filter :authenticate_user!, :except => [:funds]
+  before_filter ::login_user!, :except => [:funds]
   before_filter :check_admin!, :except => [:funds]
 
   def index

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,5 +1,5 @@
 class UsersController < ApplicationController
-  before_filter ::login_user!
+  before_filter :login_user!
 
   def show
     @user = current_user

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,5 +1,5 @@
 class UsersController < ApplicationController
-  before_filter :authenticate_user!
+  before_filter ::login_user!
 
   def show
     @user = current_user


### PR DESCRIPTION
The previous Devise method to force authentication does not automatically create an application based user session like it did under CAS SSO. We have to use another method we implement to force application session creation if one doesn't exist for OIDC. OIDC relies on the service or application to implement all session management. This change replaces the authenticate_user! method with a new login_user! method implemented in the parent application controller.