### PR TITLE
Remove redirect URI for Okta - which is autoconfigured

### DIFF
--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -263,7 +263,6 @@ Devise.setup do |config|
                 :scope => 'openid profile email netid',
                 :fields => ['profile', 'email', 'netid'],
                 :client_options => {site: okta_issuer, authorize_url: okta_issuer + "/v1/authorize", token_url: okta_issuer + "/v1/token"},
-                :redirect_uri => Rails.application.secrets.okta["redirect_url"],
                 :auth_server_id => Rails.application.secrets.okta["auth_server_id"],
                 :issuer => okta_issuer,
                 :strategy_class => OmniAuth::Strategies::Oktaoauth)


### PR DESCRIPTION
Factotum has two domain aliases - one for factotum and then also the directory. In order to allow Okta authentication via either domain name, the application needs to submit a context sensitive callback URI. If the value is not set in the applications via Devise, a default callback URI is sent to Okta which is a concatenation of <request-hostname> + /users/auth/oktaoauth/callback. This change removes the callback URI setting in the Devise initializer so that the default callback value will be used.