### PR TITLE
Removing usage of Airbrake

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -50,9 +50,6 @@ group :application do
   # update loofah
   gem "loofah", ">= 2.2.1"
 
-  # For Errbit
-  gem "airbrake", "4.3.0"
-
   gem 'sass-rails', '~> 4.0.5'
   gem 'coffee-rails', '~> 4.0.0'
   gem 'uglifier', ">= 1.3.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -54,9 +54,6 @@ GEM
       tzinfo (~> 1.1)
     addressable (2.6.0)
       public_suffix (>= 2.0.2, < 4.0)
-    airbrake (4.3.0)
-      builder
-      multi_json
     airbrussh (1.4.0)
       sshkit (>= 1.6.1, != 1.7.0)
     american_date (1.1.1)
@@ -427,7 +424,6 @@ PLATFORMS
 DEPENDENCIES
   active_attr
   activerecord-nulldb-adapter
-  airbrake (= 4.3.0)
   american_date
   backgroundrb-rails3
   better_errors

--- a/config/initializers/airbrake.rb
+++ b/config/initializers/airbrake.rb
@@ -1,6 +1,0 @@
-Airbrake.configure do |config|
-  config.api_key = "679f2a6383d89c807f5c5c7b8c0a39ff"
-  config.host    = "errbit.library.nd.edu"
-  config.port    = 443
-  config.secure  = config.port == 443
-end

--- a/config/secrets.example.yml
+++ b/config/secrets.example.yml
@@ -15,7 +15,6 @@ defaults: &defaults
     service_dn: 'service_dn'
     service_password: 'password'
     attrs: [ 'givenname', 'sn', 'cn' ]
-    airbrake_key: 'airbrake_key'
   refworks:
     ADMIN_USERNAME: 'Username'
     ADMIN_PASSWORD: 'Password'

--- a/lib/tasks/ezproxy.rake
+++ b/lib/tasks/ezproxy.rake
@@ -1,29 +1,30 @@
 namespace :ezproxy do
   desc "Clear out hosts that have not been used in 30 days"
   task :clear_unused_hosts => :environment do
-    Airbrake.configuration.rescue_rake_exceptions = true
-    require 'rubygems'
-    require 'mechanize'
+    Raven.capture do
+      require 'rubygems'
+      require 'mechanize'
 
-    agent = Mechanize.new
-    agent.verify_mode = OpenSSL::SSL::VERIFY_NONE
-    page = agent.get('https://login.proxy.library.nd.edu:443/login?user=admin&pass=DR0WSS8P&url=https://login.proxy.library.nd.edu:443/status')
+      agent = Mechanize.new
+      agent.verify_mode = OpenSSL::SSL::VERIFY_NONE
+      page = agent.get('https://login.proxy.library.nd.edu:443/login?user=admin&pass=DR0WSS8P&url=https://login.proxy.library.nd.edu:443/status')
 
-    # select the form and radio button for removing unused hosts
-    select_form = page.forms[1]
-    select_form.radiobutton_with(:value => 'm2').check
+      # select the form and radio button for removing unused hosts
+      select_form = page.forms[1]
+      select_form.radiobutton_with(:value => 'm2').check
 
-    # click the process button
-    page = agent.submit(select_form)
+      # click the process button
+      page = agent.submit(select_form)
 
-    # go to the restart page
-    page = agent.get('https://login.proxy.library.nd.edu:443/login?user=admin&pass=DR0WSS8P&url=https://login.proxy.library.nd.edu:443/restart')
+      # go to the restart page
+      page = agent.get('https://login.proxy.library.nd.edu:443/login?user=admin&pass=DR0WSS8P&url=https://login.proxy.library.nd.edu:443/restart')
 
-    # type restart into box
-    restart = page.forms.first
-    restart["confirm"] = 'RESTART'
+      # type restart into box
+      restart = page.forms.first
+      restart["confirm"] = 'RESTART'
 
-    # click here button
-    page = agent.submit(restart)
+      # click here button
+      page = agent.submit(restart)
+    end
   end
 end


### PR DESCRIPTION
With the addition of Sentry, we no longer need to send errors to
Errbit. This relates to commits:

* 6a1b27b0606f56e86d4ca04e4a98dd127525362a
* dec0f815bea27186e59b664fefa353a62858ceae